### PR TITLE
Fix batch failed with relative url & Content-Transfer-Encoding have duplicate binary

### DIFF
--- a/PanoramicData.OData.Client.Test/UnitTests/NestedExpandExpressionTests.cs
+++ b/PanoramicData.OData.Client.Test/UnitTests/NestedExpandExpressionTests.cs
@@ -50,7 +50,7 @@ public class NestedExpandExpressionTests
 	/// Tests that multiple independent expands still work correctly.
 	/// </summary>
 	[Fact]
-	public void Expand_WithMultipleIndependentProperties_ProducesCommaSepa­ratedExpands()
+	public void Expand_WithMultipleIndependentProperties_ProducesCommaSeparatedExpands()
 	{
 		// Arrange
 		var builder = new ODataQueryBuilder<Person>("People", NullLogger.Instance);

--- a/PanoramicData.OData.Client.Test/UnitTests/ODataBatchBuilderTests.cs
+++ b/PanoramicData.OData.Client.Test/UnitTests/ODataBatchBuilderTests.cs
@@ -37,9 +37,9 @@ public class ODataBatchBuilderTests : TestBase, IDisposable
 		_httpClient.Dispose();
 		GC.SuppressFinalize(this);
 	}
-	
+
 	/// <summary>
-	/// 
+	/// Verifies that the HTTP content written to the stream includes the required headers
 	/// </summary>
 	[Fact]
 	public async Task WriteToStreamAsync_ShouldIncludeRequiredHeaders()
@@ -47,12 +47,12 @@ public class ODataBatchBuilderTests : TestBase, IDisposable
 		using var request = new HttpRequestMessage(HttpMethod.Post, "http://test.org/Customers");
 		request.Content = new StringContent("{\"Name\":\"Test\"}");
 		request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-		
+
 		using var content = new HttpMessageContent(request);
-		
+
 		// Act
 		var resultString = await content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-		
+
 		// Assert: Check the HttpContent headers specifically
 		content.Headers.TryGetValues("Content-Transfer-Encoding", out var values);
 		values.Should().Contain("binary");

--- a/PanoramicData.OData.Client.Test/UnitTests/ODataBatchBuilderTests.cs
+++ b/PanoramicData.OData.Client.Test/UnitTests/ODataBatchBuilderTests.cs
@@ -1,3 +1,5 @@
+using System.Net.Http.Headers;
+
 namespace PanoramicData.OData.Client.Test.UnitTests;
 
 /// <summary>
@@ -34,6 +36,30 @@ public class ODataBatchBuilderTests : TestBase, IDisposable
 		_client.Dispose();
 		_httpClient.Dispose();
 		GC.SuppressFinalize(this);
+	}
+	
+	/// <summary>
+	/// 
+	/// </summary>
+	[Fact]
+	public async Task WriteToStreamAsync_ShouldIncludeRequiredHeaders()
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Post, "http://test.org/Customers");
+		request.Content = new StringContent("{\"Name\":\"Test\"}");
+		request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+		
+		using var content = new HttpMessageContent(request);
+		
+		// Act
+		var resultString = await content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+		
+		// Assert: Check the HttpContent headers specifically
+		content.Headers.TryGetValues("Content-Transfer-Encoding", out var values);
+		values.Should().Contain("binary");
+
+		// Assert: Check the serialized string content
+		resultString.Should().Contain("POST /Customers HTTP/1.1");
+		resultString.Should().Contain("Content-Type: application/json");
 	}
 
 	#region Get Operation Tests

--- a/PanoramicData.OData.Client.Test/UnitTests/ODataCrossJoinTests.cs
+++ b/PanoramicData.OData.Client.Test/UnitTests/ODataCrossJoinTests.cs
@@ -113,7 +113,7 @@ public class ODataCrossJoinTests
 	}
 
 	[Fact]
-	public async Task CrossJoin_LessThanTwoEntitySets_ShouldThrow()
+	public Task CrossJoin_LessThanTwoEntitySets_ShouldThrow()
 	{
 		// Arrange
 		var logger = NullLogger.Instance;
@@ -121,6 +121,7 @@ public class ODataCrossJoinTests
 		// Act & Assert
 		var act = () => new ODataCrossJoinBuilder(["Products"], logger);
 		act.Should().ThrowExactly<ArgumentException>();
+		return Task.CompletedTask;
 	}
 
 	[Fact]

--- a/PanoramicData.OData.Client.Test/UnitTests/ODataDateTimeConverterTests.cs
+++ b/PanoramicData.OData.Client.Test/UnitTests/ODataDateTimeConverterTests.cs
@@ -101,7 +101,7 @@ public class ODataDateTimeConverterTests
 	public void Read_SimpleDateFormat_ParsesCorrectly()
 	{
 		// Arrange
-		var json = "\"2024-01-15\"";
+		var json = "\"2024-01-15Z\"";
 
 		// Act
 		var result = JsonSerializer.Deserialize<DateTime>(json, _options);

--- a/PanoramicData.OData.Client/HttpMessageContent.cs
+++ b/PanoramicData.OData.Client/HttpMessageContent.cs
@@ -41,14 +41,14 @@ internal sealed class HttpMessageContent : HttpContent
 		var sb = new StringBuilder();
 
 		// Request line: METHOD path HTTP/1.1
-		var requestUri = _request.RequestUri?.PathAndQuery ?? "/";
 		sb.Append(_request.Method.ToString());
 		sb.Append(' ');
+		var requestUri = (_request.RequestUri?.IsAbsoluteUri == true ? _request.RequestUri.PathAndQuery : _request.RequestUri?.ToString()) ?? "/";
 		sb.Append(requestUri);
 		sb.AppendLine(" HTTP/1.1");
 
 		// Host header
-		if (_request.RequestUri?.Host is not null)
+		if (_request.RequestUri is { IsAbsoluteUri: true })
 		{
 			sb.Append("Host: ");
 			sb.AppendLine(_request.RequestUri.Host);

--- a/PanoramicData.OData.Client/ODataClient.Batch.cs
+++ b/PanoramicData.OData.Client/ODataClient.Batch.cs
@@ -109,8 +109,6 @@ public partial class ODataClient
 		}
 
 		var content = new HttpMessageContent(innerRequest);
-		content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/http");
-		content.Headers.TryAddWithoutValidation("Content-Transfer-Encoding", "binary");
 
 		return content;
 	}

--- a/PanoramicData.OData.Client/ODataClient.Batch.cs
+++ b/PanoramicData.OData.Client/ODataClient.Batch.cs
@@ -25,6 +25,8 @@ public partial class ODataClient
 		ODataBatchBuilder batch,
 		CancellationToken cancellationToken = default)
 	{
+		if (batch.Items.Count == 0) return new ODataBatchResponse();
+	
 		var batchBoundary = $"batch_{Guid.NewGuid():N}";
 
 		LoggerMessages.ExecuteBatchAsync(_logger, batch.Items.Count, batchBoundary);
@@ -238,18 +240,13 @@ public partial class ODataClient
 
 	private void ExtractResponseBody(string part, ODataBatchOperationResult result, List<ODataBatchOperation> operations, int operationIndex)
 	{
-		var bodyStart = part.IndexOf("\r\n\r\n", StringComparison.Ordinal);
-		if (bodyStart == -1)
-		{
-			bodyStart = part.IndexOf("\n\n", StringComparison.Ordinal);
-		}
-
+		var bodyStart = part.IndexOf('{', StringComparison.Ordinal);
 		if (bodyStart < 0)
 		{
 			return;
 		}
 
-		result.ResponseBody = part[(bodyStart + 4)..].Trim();
+		result.ResponseBody = part[bodyStart..].Trim();
 		TryDeserializeResult(result, operations, operationIndex);
 	}
 

--- a/PanoramicData.OData.Client/ODataQueryBuilder.ExpressionParsing.cs
+++ b/PanoramicData.OData.Client/ODataQueryBuilder.ExpressionParsing.cs
@@ -1,3 +1,4 @@
+using PanoramicData.OData.Client.Visitors;
 using System.Collections.Frozen;
 using System.Reflection;
 
@@ -26,37 +27,42 @@ public partial class ODataQueryBuilder<T> where T : class
 	private static string ExpressionToODataFilter(Expression expression) =>
 		ExpressionToODataFilter(expression, parentOperator: null);
 
-	private static string ExpressionToODataFilter(Expression expression, ExpressionType? parentOperator) => expression switch
-	{
-		BinaryExpression binary => ParseBinaryExpression(binary, parentOperator),
-		MethodCallExpression methodCall => ParseMethodCallExpression(methodCall),
-		UnaryExpression unary when unary.NodeType == ExpressionType.Not => $"not ({ExpressionToODataFilter(unary.Operand, parentOperator)})",
-		UnaryExpression unary when unary.NodeType == ExpressionType.Convert => ExpressionToODataFilter(unary.Operand, parentOperator),
-		MemberExpression member when member.Type == typeof(bool) && !ShouldEvaluate(member) => GetMemberPath(member),
-		MemberExpression member when ShouldEvaluate(member) => FormatValue(EvaluateExpression(member)),
-		MemberExpression member => GetMemberPath(member),
-		ConstantExpression constant => FormatValue(constant.Value),
-		_ => throw new NotSupportedException($"Expression type {expression.NodeType} is not supported")
-	};
+	private static string ExpressionToODataFilter(Expression expression, ExpressionType? parentOperator) =>
+		expression switch
+		{
+			BinaryExpression binary => ParseBinaryExpression(binary, parentOperator),
+
+			// If a call is fully constant (no lambda parameter inside), evaluate it for ANY return type.
+			MethodCallExpression methodCall when ShouldEvaluate(methodCall) => FormatValue(
+				EvaluateExpression(methodCall)),
+			MethodCallExpression methodCall => ParseMethodCallExpression(methodCall),
+
+			UnaryExpression { NodeType: ExpressionType.Not } unary =>
+				$"not ({ExpressionToODataFilter(unary.Operand, parentOperator)})",
+			UnaryExpression { NodeType: ExpressionType.Convert } unary => ExpressionToODataFilter(
+				unary.Operand, parentOperator),
+
+			MemberExpression member when member.Type == typeof(bool) && !ShouldEvaluate(member) =>
+				GetMemberPath(member),
+			MemberExpression member when ShouldEvaluate(member) => FormatValue(EvaluateExpression(member)),
+			MemberExpression member => GetMemberPath(member),
+
+			ConstantExpression constant => FormatValue(constant.Value),
+			_ => throw new NotSupportedException($"Expression type {expression.NodeType} is not supported")
+		};
 
 	/// <summary>
 	/// Determines if an expression should be evaluated (compiled and executed)
 	/// rather than converted to an OData property path.
 	/// </summary>
-	private static bool ShouldEvaluate(MemberExpression member)
+	private static bool ShouldEvaluate(Expression expression)
 	{
-		Expression? current = member;
-		while (current is MemberExpression memberExpr)
-		{
-			current = memberExpr.Expression;
-		}
+		expression = StripConvert(expression) ?? expression;
 
-		if (current is null)
-		{
-			return true;
-		}
+		var visitor = new ParameterReferenceVisitor();
+		visitor.Visit(expression);
 
-		return current is ConstantExpression;
+		return !visitor.FoundParameter;
 	}
 
 	/// <summary>
@@ -234,10 +240,20 @@ public partial class ODataQueryBuilder<T> where T : class
 
 	private static string GetStringExpressionPath(Expression expression) => expression switch
 	{
+		MemberExpression member when ShouldEvaluate(member) => FormatValue(EvaluateExpression(member)),
 		MemberExpression member => GetMemberPath(member),
+
+		// Same fix for string-path building: if a nested call is constant, evaluate it.
+		MethodCallExpression nestedMethodCall when ShouldEvaluate(nestedMethodCall) => FormatValue(
+			EvaluateExpression(nestedMethodCall)),
 		MethodCallExpression nestedMethodCall => ParseMethodCallExpression(nestedMethodCall),
-		UnaryExpression unary when unary.Operand is MemberExpression unaryMember => GetMemberPath(unaryMember),
-		_ => throw new NotSupportedException($"Expression type {expression.GetType().Name} is not supported for string operations")
+
+		UnaryExpression { Operand: MemberExpression unaryMember } when ShouldEvaluate(unaryMember)
+			=> FormatValue(EvaluateExpression(unaryMember)),
+		UnaryExpression { Operand: MemberExpression unaryMember } => GetMemberPath(unaryMember),
+
+		_ => throw new NotSupportedException(
+			$"Expression type {expression.GetType().Name} is not supported for string operations")
 	};
 
 	private static string FormatInClause(string propertyPath, System.Collections.IEnumerable values)
@@ -258,23 +274,27 @@ public partial class ODataQueryBuilder<T> where T : class
 
 	private static string GetMemberPath(MemberExpression member)
 	{
-		// Use a stack to avoid List.Insert(0) which is O(n)
-		var pathStack = new Stack<string>();
-		Expression? current = member;
-
-		while (current is MemberExpression memberExpr)
+		// If we're looking at a DateTime/DateTimeOffset component access (e.g. x.CreatedAt.Year),
+		// translate it to year(createdAt) / month(...) / etc.
+		var subject = StripConvert(member.Expression!);
+		if (subject is null)
 		{
-			pathStack.Push(memberExpr.Member.Name);
-			current = memberExpr.Expression;
+			return string.Empty;
 		}
 
-		// For small paths (common case), avoid string.Join allocation
-		return pathStack.Count switch
+		if (!TryGetDateComponentFunction(member, out var dateFunc) || !IsDateLike(subject.Type))
 		{
-			0 => string.Empty,
-			1 => pathStack.Pop(),
-			_ => string.Join("/", pathStack)
-		};
+			return BuildPlainPath(member);
+		}
+
+		// Allow x.CreatedAt.Value.Year (nullable hop)
+		if (subject is MemberExpression subjMember && IsNullableValueAccess(subjMember))
+		{
+			subject = StripConvert(subjMember.Expression!);
+		}
+
+		var innerPath = BuildPlainPath(subject);
+		return $"{dateFunc}({innerPath})";
 	}
 
 	private static object? GetValue(Expression expression) => expression switch
@@ -778,5 +798,81 @@ public partial class ODataQueryBuilder<T> where T : class
 
 			return $"{Name}({string.Join(";", options)})";
 		}
+	}
+	
+	private static bool IsNullableValueAccess(MemberExpression m) => 
+		m.Member.Name == "Value" && Nullable.GetUnderlyingType(m.Expression?.Type ?? m.Type) is not null;
+
+	private static bool IsDateLike(Type t)
+	{
+		t = Nullable.GetUnderlyingType(t) ?? t;
+		return t == typeof(DateTime) || t == typeof(DateTimeOffset);
+	}
+
+	private static bool TryGetDateComponentFunction(MemberExpression memberExpression, out string functionName)
+	{
+		functionName = string.Empty;
+		if (memberExpression.Expression is null)
+		{
+			return false;
+		}
+
+		var isDateLike = IsDateLike(memberExpression.Expression!.Type);
+		if (!isDateLike)
+		{
+			return false;
+		}
+
+		var memberName = memberExpression.Member.Name;
+		functionName = memberName switch
+		{
+			nameof(DateTime.Year) => "year",
+			nameof(DateTime.Month) => "month",
+			nameof(DateTime.Day) => "day",
+			nameof(DateTime.Hour) => "hour",
+			nameof(DateTime.Minute) => "minute",
+			nameof(DateTime.Second) => "second",
+			_ => string.Empty
+		};
+		return functionName.Length != 0;
+	}
+
+	// Builds a plain OData property path like "A/B/C", skipping Nullable<T>.Value hops.
+	private static string BuildPlainPath(Expression? expression)
+	{
+		if (expression is null)
+		{
+			return string.Empty;
+		}
+
+		var pathStack = new Stack<string>();
+		var current = StripConvert(expression);
+
+		while (current is MemberExpression memberExpr)
+		{
+			if (IsNullableValueAccess(memberExpr))
+			{
+				current = StripConvert(memberExpr.Expression);
+				continue;
+			}
+
+			pathStack.Push(memberExpr.Member.Name);
+			current = StripConvert(memberExpr.Expression);
+		}
+
+		return pathStack.Count switch
+		{
+			0 => string.Empty,
+			1 => pathStack.Pop(),
+			_ => string.Join("/", pathStack)
+		};
+	}
+	
+	private static Expression? StripConvert(Expression? e)
+	{
+		if (e is null) return null;
+		while (e is UnaryExpression { NodeType: ExpressionType.Convert } u)
+			e = u.Operand;
+		return e;
 	}
 }

--- a/PanoramicData.OData.Client/PanoramicData.OData.Client.csproj
+++ b/PanoramicData.OData.Client/PanoramicData.OData.Client.csproj
@@ -39,4 +39,8 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 	</ItemGroup>
 
+	<ItemGroup>
+  		<InternalsVisibleTo Include="PanoramicData.OData.Client.Test" />
+	</ItemGroup>
+
 </Project>

--- a/PanoramicData.OData.Client/Visitors/ParameterReferenceVisitor.cs
+++ b/PanoramicData.OData.Client/Visitors/ParameterReferenceVisitor.cs
@@ -1,0 +1,12 @@
+﻿namespace PanoramicData.OData.Client.Visitors;
+
+internal sealed class ParameterReferenceVisitor : ExpressionVisitor
+{
+	public bool FoundParameter { get; private set; }
+
+	protected override Expression VisitParameter(ParameterExpression node)
+	{
+		FoundParameter = true;
+		return base.VisitParameter(node);
+	}
+}


### PR DESCRIPTION
### Exception with relative URLs

- Add check for `IsAbsoluteUri` during `HttpMessageContent`;

### Duplicate binary in Content-Transfer-Encoding

- Remove duplicate headers in `PanoramicData.OData.Client/ODataClient.Batch.cs`, as constructor `HttpMessageContent` already init with that headers;

### UnitTests

- mark datetime UTC for `Read_SimpleDateFormat_ParsesCorrectly()`, it will failed if your local timezone is UTC + number;
- add `WriteToStreamAsync_ShouldIncludeRequiredHeaders()` for checking headers in batch;