### PR TITLE
feat: Use JsonPropertyName in $select query path generation

### DIFF
--- a/PanoramicData.OData.Client.Test/UnitTests/QueryBuilderQueryOptionsTests.cs
+++ b/PanoramicData.OData.Client.Test/UnitTests/QueryBuilderQueryOptionsTests.cs
@@ -32,7 +32,7 @@ public class QueryBuilderQueryOptionsTests
 			.BuildUrl();
 
 		url.Should().Contain("$select=");
-		url.Should().Contain("Id");
+		url.Should().Contain("ID");
 		url.Should().Contain("Name");
 	}
 

--- a/PanoramicData.OData.Client/ODataQueryBuilder.ExpressionParsing.cs
+++ b/PanoramicData.OData.Client/ODataQueryBuilder.ExpressionParsing.cs
@@ -286,7 +286,8 @@ public partial class ODataQueryBuilder<T> where T : class
 
 		while (current is MemberExpression memberExpr)
 		{
-			pathStack.Push(memberExpr.Member.Name);
+			var jsonPropertyNameAttribute = memberExpr.Member.GetCustomAttribute<JsonPropertyNameAttribute>();
+			pathStack.Push(jsonPropertyNameAttribute?.Name ?? memberExpr.Member.Name);
 			current = memberExpr.Expression;
 		}
 


### PR DESCRIPTION
OData $select paths now use JsonPropertyNameAttribute values if present, matching JSON serialization names. Updated tests to expect JSON property names instead of C# property names.

Issue #34 