### PR TITLE
Unify member-path resolution behind a shared MemberPathResolver

### DIFF
--- a/PanoramicData.OData.Client.Test/UnitTests/ExpandWithSelectTests.cs
+++ b/PanoramicData.OData.Client.Test/UnitTests/ExpandWithSelectTests.cs
@@ -126,6 +126,49 @@ public class ExpandWithSelectTests : IDisposable
 		url.Should().Contain("$top=10");
 	}
 
+	/// <summary>
+	/// Tests ExpandWithSelect with a nested (dotted) property in the select selector.
+	/// Characterization test: GetSelectFieldNames/GetDirectMemberName read only the
+	/// immediate Member.Name (no chain walk), so a nested selector silently truncates
+	/// to the leaf segment, dropping the intermediate navigation property. Pins this
+	/// bug as a safety net before the MemberPathResolver consolidation.
+	/// </summary>
+	[Fact]
+	public void ExpandWithSelect_NestedPropertyInSelector_TruncatesToLeafSegment_CharacterizationOfExistingBehavior()
+	{
+		// Arrange & Act
+		var url = _client.For<ReportBatchJob>("ReportBatchJobs")
+			.ExpandWithSelect(
+				rbj => rbj.ReportSchedule,
+				rs => rs.Owner!.Name);
+
+		var builtUrl = url.BuildUrl();
+
+		// Assert - "Owner/" is silently dropped, leaving just the leaf segment
+		builtUrl.Should().Contain("$expand=ReportSchedule($select=Name)");
+	}
+
+	/// <summary>
+	/// Tests ExpandWithSelect with a NewExpression selector mixing a direct property and a
+	/// nested (dotted) property. Characterization test: same truncation as above, but via
+	/// the NewExpression/GetDirectMemberName branch - note this silently produces the same
+	/// output as selecting ReportSchedule's own Id/Name directly.
+	/// </summary>
+	[Fact]
+	public void ExpandWithSelect_NewExpressionWithNestedProperty_TruncatesToLeafSegment_CharacterizationOfExistingBehavior()
+	{
+		// Arrange & Act
+		var url = _client.For<ReportBatchJob>("ReportBatchJobs")
+			.ExpandWithSelect(
+				rbj => rbj.ReportSchedule,
+				rs => new { rs.Id, rs.Owner!.Name });
+
+		var builtUrl = url.BuildUrl();
+
+		// Assert - "Owner/" is silently dropped from the second field
+		builtUrl.Should().Contain("$expand=ReportSchedule($select=Id,Name)");
+	}
+
 	#endregion
 
 	#region Expand with NestedExpandBuilder Tests
@@ -146,6 +189,29 @@ public class ExpandWithSelectTests : IDisposable
 
 		// Assert
 		url.Should().Contain("$expand=ReportSchedule($select=Id,Name)");
+	}
+
+	/// <summary>
+	/// Tests Expand with a nested Select using a nested (dotted) property.
+	/// Characterization test: NestedExpandBuilder.Select's private GetDirectMemberName
+	/// reads only the immediate Member.Name (no chain walk), so a nested selector
+	/// silently truncates to the leaf segment, dropping the intermediate navigation
+	/// property. Pins this bug as a safety net before the MemberPathResolver
+	/// consolidation.
+	/// </summary>
+	[Fact]
+	public void Expand_NestedSelectWithNestedProperty_TruncatesToLeafSegment_CharacterizationOfExistingBehavior()
+	{
+		// Arrange & Act
+		var query = _client.For<ReportBatchJob>("ReportBatchJobs")
+			.Expand(
+				rbj => rbj.ReportSchedule,
+				nested => nested.Select(rs => rs.Owner!.Name));
+
+		var url = query.BuildUrl();
+
+		// Assert - "Owner/" is silently dropped, leaving just the leaf segment
+		url.Should().Contain("$expand=ReportSchedule($select=Name)");
 	}
 
 	/// <summary>

--- a/PanoramicData.OData.Client.Test/UnitTests/ODataClientQueryTests.cs
+++ b/PanoramicData.OData.Client.Test/UnitTests/ODataClientQueryTests.cs
@@ -242,6 +242,22 @@ public class ODataClientQueryTests : TestBase, IDisposable
 	}
 
 	/// <summary>
+	/// Tests that non-generic NavigateTo(expr) with a nested (dotted) member path truncates
+	/// to the leaf segment. Characterization test: NavigateTo shares GetMemberName with
+	/// OrderBy, which reads only the selector body's immediate Member.Name (no chain walk).
+	/// Pins this bug as a safety net before the MemberPathResolver consolidation.
+	/// </summary>
+	[Fact]
+	public void NavigateTo_NonGenericExprNested_TruncatesToLeafSegment_CharacterizationOfExistingBehavior()
+	{
+		// Act
+		var url = _client.For<Person>("People").Key("russellwhyte").NavigateTo(x => x.BestFriend!.Friends).BuildUrl();
+
+		// Assert - "BestFriend/" is silently dropped, leaving just the leaf segment
+		url.Should().Be("People('russellwhyte')/Friends");
+	}
+
+	/// <summary>
 	/// Tests that As&lt;T&gt;() after non-generic NavigateTo preserves the navigation path.
 	/// </summary>
 	[Fact]

--- a/PanoramicData.OData.Client.Test/UnitTests/QueryBuilderAnyAllTests.cs
+++ b/PanoramicData.OData.Client.Test/UnitTests/QueryBuilderAnyAllTests.cs
@@ -73,6 +73,26 @@ public class QueryBuilderAnyAllTests
 	}
 
 	/// <summary>
+	/// Tests that Any() with a nested (two-hop) member path inside the predicate generates
+	/// correct URL. Characterization test: GetLambdaMemberPath currently walks the full
+	/// chain correctly here, but this exact scenario was previously untested. Pins it as a
+	/// safety net before the MemberPathResolver consolidation (which changes the internal
+	/// List.Insert(0,...) walk to a Stack-based one with byte-identical output).
+	/// </summary>
+	[Fact]
+	public void Filter_WithAnyNestedMemberPath_GeneratesCorrectUrl()
+	{
+		// Arrange & Act
+		var url = _queryBuilder
+			.Filter(p => p.Friends!.Any(f => f.BestFriend!.FirstName == "John"))
+			.BuildUrl();
+
+		// Assert
+		// Friends/any(f: f/BestFriend/FirstName eq 'John')
+		url.Should().Contain("Friends%2Fany%28f%3A%20f%2FBestFriend%2FFirstName%20eq%20%27John%27%29");
+	}
+
+	/// <summary>
 	/// Tests that Any() with greater than comparison generates correct URL.
 	/// </summary>
 	[Fact]
@@ -249,6 +269,30 @@ public class QueryBuilderAnyAllTests
 		// Act
 		var url = _queryBuilder
 			.Filter(p => p.Friends!.Any(f => f.Age >= minAge))
+			.BuildUrl();
+
+		// Assert
+		url.Should().Contain("f%2FAge%20ge%2021");
+	}
+
+	/// <summary>
+	/// Tests that a two-hop closure member access (a captured anonymous object's property,
+	/// rather than a captured local directly) works in an Any lambda. Characterization test:
+	/// GetLambdaMemberPath walks the chain until it hits the ConstantExpression root, then
+	/// discards the partially-built path and evaluates the original member expression
+	/// directly - this exercises that discard-and-evaluate branch with more than one hop
+	/// before the root, which the existing single-hop closure tests don't reach. Pins this
+	/// as a safety net before the MemberPathResolver consolidation.
+	/// </summary>
+	[Fact]
+	public void Filter_WithAnyNestedClosureMemberAccess_GeneratesCorrectUrl()
+	{
+		// Arrange
+		var ageFilter = new { MinAge = 21 };
+
+		// Act
+		var url = _queryBuilder
+			.Filter(p => p.Friends!.Any(f => f.Age >= ageFilter.MinAge))
 			.BuildUrl();
 
 		// Assert

--- a/PanoramicData.OData.Client.Test/UnitTests/QueryBuilderFilterTests.cs
+++ b/PanoramicData.OData.Client.Test/UnitTests/QueryBuilderFilterTests.cs
@@ -380,4 +380,25 @@ public class QueryBuilderFilterTests
 	}
 
 	#endregion
+
+	#region Nested Member Paths
+
+	/// <summary>
+	/// Tests filter with a nested (dotted) member path resolves the full path.
+	/// Characterization test: pins the currently-correct full-chain walk in GetMemberPath
+	/// as a safety net before the MemberPathResolver consolidation.
+	/// </summary>
+	[Fact]
+	public void Filter_WithNestedMemberPath_GeneratesCorrectUrl()
+	{
+		// Arrange & Act
+		var url = new ODataQueryBuilder<Person>("People", NullLogger.Instance)
+			.Filter(p => p.BestFriend!.FirstName == "John")
+			.BuildUrl();
+
+		// Assert - BestFriend/FirstName eq 'John'
+		url.Should().Contain("BestFriend%2FFirstName%20eq%20%27John%27");
+	}
+
+	#endregion
 }

--- a/PanoramicData.OData.Client.Test/UnitTests/QueryBuilderQueryOptionsTests.cs
+++ b/PanoramicData.OData.Client.Test/UnitTests/QueryBuilderQueryOptionsTests.cs
@@ -50,6 +50,24 @@ public class QueryBuilderQueryOptionsTests
 		url.Should().Contain("$select=ID,Name,Price");
 	}
 
+	/// <summary>
+	/// Tests select with a nested (dotted) member path.
+	/// Characterization test: GetMemberNames currently takes only the FIRST path segment
+	/// (Split('/')[0]) of the full path GetMemberPath resolves, so a nested selector
+	/// silently collapses to just the navigation property name. Pins this quirk as a
+	/// safety net before the MemberPathResolver consolidation.
+	/// </summary>
+	[Fact]
+	public void Select_WithNestedExpression_UsesOnlyFirstSegment_CharacterizationOfExistingBehavior()
+	{
+		var url = new ODataQueryBuilder<Person>("People", NullLogger.Instance)
+			.Select(p => p.BestFriend!.FirstName)
+			.BuildUrl();
+
+		url.Should().Contain("$select=BestFriend");
+		url.Should().NotContain("FirstName");
+	}
+
 	#endregion
 
 	#region $expand
@@ -205,6 +223,24 @@ public class QueryBuilderQueryOptionsTests
 			.BuildUrl();
 
 		url.Should().Contain("$orderby=Price desc");
+	}
+
+	/// <summary>
+	/// Tests orderby with a nested (dotted) member path.
+	/// Characterization test: GetMemberName reads only the selector body's immediate
+	/// Member.Name (no chain walk), so a nested selector silently truncates to the leaf
+	/// segment, dropping the navigation property. Pins this bug as a safety net before
+	/// the MemberPathResolver consolidation.
+	/// </summary>
+	[Fact]
+	public void OrderBy_WithNestedExpression_TruncatesToLeafSegment_CharacterizationOfExistingBehavior()
+	{
+		var url = new ODataQueryBuilder<Person>("People", NullLogger.Instance)
+			.OrderBy(p => p.BestFriend!.FirstName)
+			.BuildUrl();
+
+		url.Should().Contain("$orderby=FirstName");
+		url.Should().NotContain("BestFriend");
 	}
 
 	/// <summary>

--- a/PanoramicData.OData.Client/MemberPathResolver.cs
+++ b/PanoramicData.OData.Client/MemberPathResolver.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Reflection;
 
 namespace PanoramicData.OData.Client;

--- a/PanoramicData.OData.Client/MemberPathResolver.cs
+++ b/PanoramicData.OData.Client/MemberPathResolver.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using System.Reflection;
+
+namespace PanoramicData.OData.Client;
+
+/// <summary>
+/// Shared logic for resolving a LINQ <see cref="MemberExpression"/> chain into OData path segments.
+/// Consolidates what were previously several independent, hand-rolled implementations across
+/// <see cref="ODataQueryBuilder{T}"/> and <see cref="NestedExpandBuilder{T}"/>.
+/// </summary>
+internal static class MemberPathResolver
+{
+	/// <summary>
+	/// Walks a member access chain (e.g. <c>p.BestFriend.FirstName</c>) from leaf to root,
+	/// returning each segment's name and <see cref="MemberInfo"/>, plus the terminal
+	/// (non-<see cref="MemberExpression"/>) root expression - typically the lambda parameter,
+	/// a closure <see cref="ConstantExpression"/>, or <see langword="null"/>.
+	/// </summary>
+	internal static (Stack<(string Name, MemberInfo Member)> Segments, Expression? Root) WalkChain(MemberExpression member)
+	{
+		var segments = new Stack<(string Name, MemberInfo Member)>();
+		Expression? current = member;
+
+		while (current is MemberExpression memberExpr)
+		{
+			segments.Push((memberExpr.Member.Name, memberExpr.Member));
+			current = memberExpr.Expression;
+		}
+
+		return (segments, current);
+	}
+
+	/// <summary>
+	/// Resolves a member access chain to a flat, slash-separated OData path (e.g. <c>BestFriend/FirstName</c>).
+	/// </summary>
+	internal static string GetFlatPath(MemberExpression member)
+	{
+		var (segments, _) = WalkChain(member);
+
+		// For small paths (common case), avoid string.Join allocation
+		return segments.Count switch
+		{
+			0 => string.Empty,
+			1 => segments.Pop().Name,
+			_ => string.Join("/", segments.Select(s => s.Name))
+		};
+	}
+}

--- a/PanoramicData.OData.Client/MemberPathResolver.cs
+++ b/PanoramicData.OData.Client/MemberPathResolver.cs
@@ -45,4 +45,96 @@ internal static class MemberPathResolver
 			_ => string.Join("/", segments.Select(s => s.Name))
 		};
 	}
+
+	/// <summary>
+	/// Resolves a member access chain to a root-to-leaf list of <see cref="ExpandSegment"/>,
+	/// each flagged as navigation (entity reference/collection) or scalar. Returns
+	/// <see langword="null"/> only when <paramref name="member"/>'s chain is empty, which
+	/// cannot occur given a non-null <see cref="MemberExpression"/> input - preserved to
+	/// mirror the original implementation's guard exactly.
+	/// </summary>
+	internal static List<ExpandSegment>? GetExpandSegments(MemberExpression member)
+	{
+		var (chain, _) = WalkChain(member);
+
+		if (chain.Count == 0)
+		{
+			return null;
+		}
+
+		var segments = new List<ExpandSegment>(chain.Count);
+
+		foreach (var (name, memberInfo) in chain)
+		{
+			segments.Add(memberInfo is PropertyInfo propInfo
+				? new ExpandSegment(propInfo.Name, IsNavigationProperty(propInfo))
+				: new ExpandSegment(name, false));
+		}
+
+		return segments;
+	}
+
+	/// <summary>
+	/// Determines if a property is a navigation property (vs a scalar property).
+	/// Navigation properties are entity references or collections of entities.
+	/// Scalar properties are primitives, strings, dates, guids, etc.
+	/// </summary>
+	internal static bool IsNavigationProperty(PropertyInfo property)
+	{
+		var propertyType = property.PropertyType;
+
+		// Check for nullable types - get underlying type
+		var underlyingType = Nullable.GetUnderlyingType(propertyType);
+		if (underlyingType is not null)
+		{
+			propertyType = underlyingType;
+		}
+
+		// Primitives are scalar
+		if (propertyType.IsPrimitive)
+		{
+			return false;
+		}
+
+		// Common scalar types
+		if (propertyType == typeof(string) ||
+			propertyType == typeof(DateTime) ||
+			propertyType == typeof(DateTimeOffset) ||
+			propertyType == typeof(DateOnly) ||
+			propertyType == typeof(TimeOnly) ||
+			propertyType == typeof(TimeSpan) ||
+			propertyType == typeof(Guid) ||
+			propertyType == typeof(decimal))
+		{
+			return false;
+		}
+
+		// Enums are scalar
+		if (propertyType.IsEnum)
+		{
+			return false;
+		}
+
+		// byte[] is scalar (used for binary data)
+		if (propertyType == typeof(byte[]))
+		{
+			return false;
+		}
+
+		// Collections of entities are navigation properties (but not string which is IEnumerable<char>)
+		if (typeof(System.Collections.IEnumerable).IsAssignableFrom(propertyType) &&
+			propertyType != typeof(string))
+		{
+			return true;
+		}
+
+		// Reference types that are classes are typically navigation properties
+		// (entity references like Tenant, Role, etc.)
+		return propertyType.IsClass;
+	}
 }
+
+/// <summary>
+/// Represents a segment in an expand path with property type information.
+/// </summary>
+internal sealed record ExpandSegment(string Name, bool IsNavigation);

--- a/PanoramicData.OData.Client/MemberPathResolver.cs
+++ b/PanoramicData.OData.Client/MemberPathResolver.cs
@@ -92,6 +92,34 @@ internal static class MemberPathResolver
 	}
 
 	/// <summary>
+	/// Resolves the leaf (immediate) member name of a single-hop selector body, using a looser
+	/// unwrap than <see cref="GetLeafMemberNameOrEmpty"/>: matches ANY <see cref="UnaryExpression"/>
+	/// wrapping a <see cref="MemberExpression"/>, not just <see cref="ExpressionType.Convert"/>, and
+	/// does not itself unwrap before the primary check (only the fallback branch inspects a
+	/// Unary's <see cref="UnaryExpression.Operand"/>). Kept deliberately distinct from
+	/// <see cref="GetLeafMemberNameOrEmpty"/> - the two gates coincide for every expression shape
+	/// the C# compiler currently emits here, but must not be silently unified. Does NOT walk nested
+	/// chains - returns just the last segment's name for a multi-hop selector.
+	/// </summary>
+	internal static bool TryGetLeafMemberNameLoose(Expression expression, out string name)
+	{
+		if (expression is MemberExpression member)
+		{
+			name = member.Member.Name;
+			return true;
+		}
+
+		if (expression is UnaryExpression unary && unary.Operand is MemberExpression unaryMember)
+		{
+			name = unaryMember.Member.Name;
+			return true;
+		}
+
+		name = string.Empty;
+		return false;
+	}
+
+	/// <summary>
 	/// Determines if a property is a navigation property (vs a scalar property).
 	/// Navigation properties are entity references or collections of entities.
 	/// Scalar properties are primitives, strings, dates, guids, etc.

--- a/PanoramicData.OData.Client/MemberPathResolver.cs
+++ b/PanoramicData.OData.Client/MemberPathResolver.cs
@@ -75,6 +75,24 @@ internal static class MemberPathResolver
 	}
 
 	/// <summary>
+	/// Resolves the leaf (immediate) member name of a single-hop selector body (e.g. <c>p.Orders</c>),
+	/// unwrapping a single <see cref="ExpressionType.Convert"/> (such as the null-forgiving operator)
+	/// if present. Does NOT walk nested chains - returns just the last segment's name for a
+	/// multi-hop selector (e.g. <c>p.Nav.Prop</c> resolves to <c>"Prop"</c>). Returns
+	/// <see cref="string.Empty"/> if <paramref name="expression"/> isn't (optionally Convert-wrapped)
+	/// a <see cref="MemberExpression"/>.
+	/// </summary>
+	internal static string GetLeafMemberNameOrEmpty(Expression expression)
+	{
+		if (expression is UnaryExpression unary && unary.NodeType == ExpressionType.Convert)
+		{
+			expression = unary.Operand;
+		}
+
+		return expression is MemberExpression member ? member.Member.Name : string.Empty;
+	}
+
+	/// <summary>
 	/// Determines if a property is a navigation property (vs a scalar property).
 	/// Navigation properties are entity references or collections of entities.
 	/// Scalar properties are primitives, strings, dates, guids, etc.

--- a/PanoramicData.OData.Client/NestedExpandBuilder.cs
+++ b/PanoramicData.OData.Client/NestedExpandBuilder.cs
@@ -29,7 +29,7 @@ public class NestedExpandBuilder<T> where T : class
 		{
 			foreach (var arg in newExpr.Arguments)
 			{
-				var memberName = GetDirectMemberName(arg);
+				var memberName = MemberPathResolver.GetLeafMemberNameOrEmpty(arg);
 				if (!string.IsNullOrEmpty(memberName) && !_selectFields.Contains(memberName))
 				{
 					_selectFields.Add(memberName);
@@ -62,16 +62,11 @@ public class NestedExpandBuilder<T> where T : class
 	/// </summary>
 	public NestedExpandBuilder<T> Expand(Expression<Func<T, object?>> selector)
 	{
-		var body = selector.Body;
+		var memberName = MemberPathResolver.GetLeafMemberNameOrEmpty(selector.Body);
 
-		if (body is UnaryExpression unary && unary.NodeType == ExpressionType.Convert)
+		if (!string.IsNullOrEmpty(memberName))
 		{
-			body = unary.Operand;
-		}
-
-		if (body is MemberExpression member)
-		{
-			_expandFields.Add(member.Member.Name);
+			_expandFields.Add(memberName);
 		}
 
 		return this;
@@ -173,20 +168,5 @@ public class NestedExpandBuilder<T> where T : class
 		}
 
 		return string.Join(";", options);
-	}
-
-	private static string GetDirectMemberName(Expression expression)
-	{
-		if (expression is UnaryExpression unary && unary.NodeType == ExpressionType.Convert)
-		{
-			expression = unary.Operand;
-		}
-
-		if (expression is MemberExpression member)
-		{
-			return member.Member.Name;
-		}
-
-		return string.Empty;
 	}
 }

--- a/PanoramicData.OData.Client/ODataQueryBuilder.ExpressionParsing.cs
+++ b/PanoramicData.OData.Client/ODataQueryBuilder.ExpressionParsing.cs
@@ -278,26 +278,7 @@ public partial class ODataQueryBuilder<T> where T : class
 		return $"{propertyPath} in ({string.Join(",", formattedValues)})";
 	}
 
-	private static string GetMemberPath(MemberExpression member)
-	{
-		// Use a stack to avoid List.Insert(0) which is O(n)
-		var pathStack = new Stack<string>();
-		Expression? current = member;
-
-		while (current is MemberExpression memberExpr)
-		{
-			pathStack.Push(memberExpr.Member.Name);
-			current = memberExpr.Expression;
-		}
-
-		// For small paths (common case), avoid string.Join allocation
-		return pathStack.Count switch
-		{
-			0 => string.Empty,
-			1 => pathStack.Pop(),
-			_ => string.Join("/", pathStack)
-		};
-	}
+	private static string GetMemberPath(MemberExpression member) => MemberPathResolver.GetFlatPath(member);
 
 	private static object? GetValue(Expression expression) => expression switch
 	{

--- a/PanoramicData.OData.Client/ODataQueryBuilder.ExpressionParsing.cs
+++ b/PanoramicData.OData.Client/ODataQueryBuilder.ExpressionParsing.cs
@@ -579,88 +579,9 @@ public partial class ODataQueryBuilder<T> where T : class
 			return null;
 		}
 
-		var segments = new List<ExpandSegment>();
-		Expression? current = member;
+		var segments = MemberPathResolver.GetExpandSegments(member);
 
-		while (current is MemberExpression memberExpr)
-		{
-			if (memberExpr.Member is PropertyInfo propInfo)
-			{
-				segments.Insert(0, new ExpandSegment(propInfo.Name, IsNavigationProperty(propInfo)));
-			}
-			else
-			{
-				segments.Insert(0, new ExpandSegment(memberExpr.Member.Name, false));
-			}
-
-			current = memberExpr.Expression;
-		}
-
-		if (segments.Count == 0)
-		{
-			return null;
-		}
-
-		return new ExpandPathInfo(segments);
-	}
-
-	/// <summary>
-	/// Determines if a property is a navigation property (vs a scalar property).
-	/// Navigation properties are entity references or collections of entities.
-	/// Scalar properties are primitives, strings, dates, guids, etc.
-	/// </summary>
-	private static bool IsNavigationProperty(PropertyInfo property)
-	{
-		var propertyType = property.PropertyType;
-
-		// Check for nullable types - get underlying type
-		var underlyingType = Nullable.GetUnderlyingType(propertyType);
-		if (underlyingType is not null)
-		{
-			propertyType = underlyingType;
-		}
-
-		// Primitives are scalar
-		if (propertyType.IsPrimitive)
-		{
-			return false;
-		}
-
-		// Common scalar types
-		if (propertyType == typeof(string) ||
-			propertyType == typeof(DateTime) ||
-			propertyType == typeof(DateTimeOffset) ||
-			propertyType == typeof(DateOnly) ||
-			propertyType == typeof(TimeOnly) ||
-			propertyType == typeof(TimeSpan) ||
-			propertyType == typeof(Guid) ||
-			propertyType == typeof(decimal))
-		{
-			return false;
-		}
-
-		// Enums are scalar
-		if (propertyType.IsEnum)
-		{
-			return false;
-		}
-
-		// byte[] is scalar (used for binary data)
-		if (propertyType == typeof(byte[]))
-		{
-			return false;
-		}
-
-		// Collections of entities are navigation properties (but not string which is IEnumerable<char>)
-		if (typeof(System.Collections.IEnumerable).IsAssignableFrom(propertyType) &&
-			propertyType != typeof(string))
-		{
-			return true;
-		}
-
-		// Reference types that are classes are typically navigation properties
-		// (entity references like Tenant, Role, etc.)
-		return propertyType.IsClass;
+		return segments is null ? null : new ExpandPathInfo(segments);
 	}
 
 	/// <summary>
@@ -749,11 +670,6 @@ public partial class ODataQueryBuilder<T> where T : class
 		// Continue with remaining segments as children
 		AddPathToTreeWithInfo(node.Children, segments, index + 1);
 	}
-
-	/// <summary>
-	/// Represents a segment in an expand path with property type information.
-	/// </summary>
-	private sealed record ExpandSegment(string Name, bool IsNavigation);
 
 	/// <summary>
 	/// Represents an expand path with its segments and property type information.

--- a/PanoramicData.OData.Client/ODataQueryBuilder.ExpressionParsing.cs
+++ b/PanoramicData.OData.Client/ODataQueryBuilder.ExpressionParsing.cs
@@ -508,20 +508,10 @@ public partial class ODataQueryBuilder<T> where T : class
 		return string.Empty;
 	}
 
-	private static string GetMemberName(Expression<Func<T, object?>> selector)
-	{
-		if (selector.Body is MemberExpression member)
-		{
-			return member.Member.Name;
-		}
-
-		if (selector.Body is UnaryExpression unary && unary.Operand is MemberExpression unaryMember)
-		{
-			return unaryMember.Member.Name;
-		}
-
-		throw new ArgumentException("Invalid selector expression");
-	}
+	private static string GetMemberName(Expression<Func<T, object?>> selector) =>
+		MemberPathResolver.TryGetLeafMemberNameLoose(selector.Body, out var name)
+			? name
+			: throw new ArgumentException("Invalid selector expression");
 
 	/// <summary>
 	/// Gets full member paths from an expand expression.

--- a/PanoramicData.OData.Client/ODataQueryBuilder.LambdaParsing.cs
+++ b/PanoramicData.OData.Client/ODataQueryBuilder.LambdaParsing.cs
@@ -196,24 +196,19 @@ public partial class ODataQueryBuilder<T> where T : class
 
 	private static string GetLambdaMemberPath(MemberExpression member, ParameterExpression lambdaParam, string odataParamName)
 	{
-		var path = new List<string>();
-		Expression? current = member;
+		var (segments, root) = MemberPathResolver.WalkChain(member);
+		var names = segments.Select(s => s.Name);
 
-		while (current is MemberExpression memberExpr)
+		if (root == lambdaParam)
 		{
-			path.Insert(0, memberExpr.Member.Name);
-			current = memberExpr.Expression;
+			return string.Join("/", new[] { odataParamName }.Concat(names));
 		}
 
-		if (current == lambdaParam)
-		{
-			path.Insert(0, odataParamName);
-		}
-		else if (current is ConstantExpression)
+		if (root is ConstantExpression)
 		{
 			return FormatValue(EvaluateExpression(member));
 		}
 
-		return string.Join("/", path);
+		return string.Join("/", names);
 	}
 }

--- a/PanoramicData.OData.Client/ODataQueryBuilder.cs
+++ b/PanoramicData.OData.Client/ODataQueryBuilder.cs
@@ -485,7 +485,7 @@ public partial class ODataQueryBuilder<T> where T : class
 		{
 			foreach (var arg in newExpr.Arguments)
 			{
-				var memberName = GetDirectMemberName(arg);
+				var memberName = MemberPathResolver.GetLeafMemberNameOrEmpty(arg);
 				if (!string.IsNullOrEmpty(memberName) && !results.Contains(memberName))
 				{
 					results.Add(memberName);
@@ -498,21 +498,6 @@ public partial class ODataQueryBuilder<T> where T : class
 		}
 
 		return results;
-	}
-
-	private static string GetDirectMemberName(Expression expression)
-	{
-		if (expression is UnaryExpression unary && unary.NodeType == ExpressionType.Convert)
-		{
-			expression = unary.Operand;
-		}
-
-		if (expression is MemberExpression member)
-		{
-			return member.Member.Name;
-		}
-
-		return string.Empty;
 	}
 
 	/// <summary>

--- a/PanoramicData.OData.Client/ODataQueryBuilder.cs
+++ b/PanoramicData.OData.Client/ODataQueryBuilder.cs
@@ -463,41 +463,11 @@ public partial class ODataQueryBuilder<T> where T : class
 		return this;
 	}
 
-	private static string GetNavigationPropertyName<TNav>(Expression<Func<T, TNav?>> selector)
-	{
-		var body = selector.Body;
+	private static string GetNavigationPropertyName<TNav>(Expression<Func<T, TNav?>> selector) =>
+		MemberPathResolver.GetLeafMemberNameOrEmpty(selector.Body);
 
-		// Handle null-forgiving operator (!.)
-		if (body is UnaryExpression unary && unary.NodeType == ExpressionType.Convert)
-		{
-			body = unary.Operand;
-		}
-
-		if (body is MemberExpression member)
-		{
-			return member.Member.Name;
-		}
-
-		return string.Empty;
-	}
-
-	private static string GetCollectionNavigationPropertyName<TNav>(Expression<Func<T, IEnumerable<TNav>?>> selector)
-	{
-		var body = selector.Body;
-
-		// Handle null-forgiving operator (!.)
-		if (body is UnaryExpression unary && unary.NodeType == ExpressionType.Convert)
-		{
-			body = unary.Operand;
-		}
-
-		if (body is MemberExpression member)
-		{
-			return member.Member.Name;
-		}
-
-		return string.Empty;
-	}
+	private static string GetCollectionNavigationPropertyName<TNav>(Expression<Func<T, IEnumerable<TNav>?>> selector) =>
+		MemberPathResolver.GetLeafMemberNameOrEmpty(selector.Body);
 
 	private static List<string> GetSelectFieldNames<TEntity>(Expression<Func<TEntity, object?>> selector)
 	{


### PR DESCRIPTION
## Summary

Consolidates seven independent, hand-rolled implementations that resolve a LINQ `MemberExpression` chain into an OData path segment - used by `$filter`, top-level `$select`, `$orderby`/`NavigateTo`, top-level `$expand`, `ExpandWithSelect`, the `NestedExpandBuilder` nested-configure callback, and `Any`/`All` predicates - into one shared internal `MemberPathResolver`.

**Zero intended behavior change.** ~11 characterization tests were added *first*, in their own commit, before any production code changed, pinning today's exact output for nested/dotted property paths across all seven call sites - including four pre-existing truncation bugs/quirks that are deliberately **preserved, not fixed**, in this PR:
- `.OrderBy(p => p.Nav.Prop)` / `.NavigateTo(p => p.Nav.Prop)` silently truncate to `Prop`, dropping `Nav/`.
- `.Select(p => p.Nav.Prop)` silently truncates to `Nav`, dropping `/Prop` (opposite direction).
- `.ExpandWithSelect(nav, x => x.Deeper.Prop)` and `NestedExpandBuilder`'s nested `.Select(x => x.Deeper.Prop)` truncate the same way as `OrderBy`.

As a side effect, this also replaces the `Any`/`All` lambda parser's `List.Insert(0,...)` (O(n²)) walk with the same Stack-based (O(n)) approach already used elsewhere, with byte-identical output.

**Why:** while reviewing an external PR that patches `[JsonPropertyName]`-awareness into exactly one of these seven call sites (creating an inconsistency - `.Filter()` would honor the attribute, `.OrderBy()` wouldn't), we found the underlying duplication was the real problem. This PR does the prerequisite consolidation only. Adopting `[JsonPropertyName]` support, or fixing the four truncation bugs above, is intentionally **out of scope** here - each becomes a single-place change to `MemberPathResolver` once this lands.

## Verified

- Full test suite green on every commit: **786/786** passing (777 pre-existing + ~11 new characterization tests).
- Clean Release build, zero warnings (`TreatWarningsAsErrors`).
- Characterization test assertions are **byte-identical** from the first (tests-only) commit through the final migration commit - confirmed via `git diff` on those files.
- `MemberPathResolver` and the relocated `ExpandSegment` record remain `internal` - no public API surface added.
- 14 independent adversarial code reviews (2 per migrated function, one control-flow angle and one edge-case angle) each hand-traced old vs. new logic and found **zero behavioral divergence** - covering Stack vs. List enumeration order, Convert-vs-loose-Unary gating differences (deliberately preserved as two distinct methods, not unified), reference-equality on the lambda parameter, closure evaluation, and FieldInfo vs. PropertyInfo members.

## Test plan

- [x] `dotnet build -c Release` - 0 warnings, 0 errors
- [x] `dotnet test` - 786/786 passed
- [x] Diffed characterization test files between first and last commit - empty diff
- [x] Multi-agent adversarial review of each of the 7 migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)