### PR TITLE
Fix .OrderBy/.NavigateTo truncating nested (dotted) property paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.0.88] - 2026-07-08
+
+### Fixed
+- Fix `.OrderBy(p => p.Nav.Prop)` and `.NavigateTo(p => p.Nav.Prop)` resolving only the leaf property name (e.g. `$orderby=FirstName`) instead of the full navigation path (`$orderby=BestFriend/FirstName`) for nested (dotted) property selectors
+
 ## [10.0.87] - 2026-06-12
 
 ### Added

--- a/PanoramicData.OData.Client.Test/UnitTests/ODataClientQueryTests.cs
+++ b/PanoramicData.OData.Client.Test/UnitTests/ODataClientQueryTests.cs
@@ -242,19 +242,18 @@ public class ODataClientQueryTests : TestBase, IDisposable
 	}
 
 	/// <summary>
-	/// Tests that non-generic NavigateTo(expr) with a nested (dotted) member path truncates
-	/// to the leaf segment. Characterization test: NavigateTo shares GetMemberName with
-	/// OrderBy, which reads only the selector body's immediate Member.Name (no chain walk).
-	/// Pins this bug as a safety net before the MemberPathResolver consolidation.
+	/// Tests that non-generic NavigateTo(expr) with a nested (dotted) member path resolves the
+	/// full navigation path. NavigateTo shares GetMemberName with OrderBy; both now walk the
+	/// full chain instead of returning just the leaf segment.
 	/// </summary>
 	[Fact]
-	public void NavigateTo_NonGenericExprNested_TruncatesToLeafSegment_CharacterizationOfExistingBehavior()
+	public void NavigateTo_NonGenericExprNested_ResolvesFullPath()
 	{
 		// Act
 		var url = _client.For<Person>("People").Key("russellwhyte").NavigateTo(x => x.BestFriend!.Friends).BuildUrl();
 
-		// Assert - "BestFriend/" is silently dropped, leaving just the leaf segment
-		url.Should().Be("People('russellwhyte')/Friends");
+		// Assert
+		url.Should().Be("People('russellwhyte')/BestFriend/Friends");
 	}
 
 	/// <summary>

--- a/PanoramicData.OData.Client.Test/UnitTests/QueryBuilderQueryOptionsTests.cs
+++ b/PanoramicData.OData.Client.Test/UnitTests/QueryBuilderQueryOptionsTests.cs
@@ -226,21 +226,31 @@ public class QueryBuilderQueryOptionsTests
 	}
 
 	/// <summary>
-	/// Tests orderby with a nested (dotted) member path.
-	/// Characterization test: GetMemberName reads only the selector body's immediate
-	/// Member.Name (no chain walk), so a nested selector silently truncates to the leaf
-	/// segment, dropping the navigation property. Pins this bug as a safety net before
-	/// the MemberPathResolver consolidation.
+	/// Tests orderby with a nested (dotted) member path resolves the full navigation path.
+	/// OData v4's $orderby grammar supports "/"-paths through navigation properties, so this
+	/// is spec-compliant (unlike the still-deferred $select-family nested-path fixes).
 	/// </summary>
 	[Fact]
-	public void OrderBy_WithNestedExpression_TruncatesToLeafSegment_CharacterizationOfExistingBehavior()
+	public void OrderBy_WithNestedExpression_ResolvesFullPath()
 	{
 		var url = new ODataQueryBuilder<Person>("People", NullLogger.Instance)
 			.OrderBy(p => p.BestFriend!.FirstName)
 			.BuildUrl();
 
-		url.Should().Contain("$orderby=FirstName");
-		url.Should().NotContain("BestFriend");
+		url.Should().Contain("$orderby=BestFriend/FirstName");
+	}
+
+	/// <summary>
+	/// Tests orderby with a 3-level nested member path resolves the full navigation path.
+	/// </summary>
+	[Fact]
+	public void OrderBy_WithThreeLevelNestedExpression_ResolvesFullPath()
+	{
+		var url = new ODataQueryBuilder<Person>("People", NullLogger.Instance)
+			.OrderBy(p => p.BestFriend!.BestFriend!.FirstName)
+			.BuildUrl();
+
+		url.Should().Contain("$orderby=BestFriend/BestFriend/FirstName");
 	}
 
 	/// <summary>

--- a/PanoramicData.OData.Client/MemberPathResolver.cs
+++ b/PanoramicData.OData.Client/MemberPathResolver.cs
@@ -120,6 +120,33 @@ internal static class MemberPathResolver
 	}
 
 	/// <summary>
+	/// Resolves the full, slash-separated OData path of a selector body, using the same loose
+	/// Unary-gated unwrap as <see cref="TryGetLeafMemberNameLoose"/>. Unlike that method, this
+	/// walks the full chain via <see cref="GetFlatPath"/> instead of returning just the leaf
+	/// segment (e.g. <c>p.BestFriend.FirstName</c> resolves to <c>"BestFriend/FirstName"</c>).
+	/// Kept deliberately distinct from <see cref="TryGetLeafMemberNameLoose"/> for the same
+	/// reason that method is kept distinct from <see cref="GetLeafMemberNameOrEmpty"/> - the
+	/// gates coincide today but must not be silently unified.
+	/// </summary>
+	internal static bool TryGetPathLoose(Expression expression, out string path)
+	{
+		if (expression is MemberExpression member)
+		{
+			path = GetFlatPath(member);
+			return true;
+		}
+
+		if (expression is UnaryExpression unary && unary.Operand is MemberExpression unaryMember)
+		{
+			path = GetFlatPath(unaryMember);
+			return true;
+		}
+
+		path = string.Empty;
+		return false;
+	}
+
+	/// <summary>
 	/// Determines if a property is a navigation property (vs a scalar property).
 	/// Navigation properties are entity references or collections of entities.
 	/// Scalar properties are primitives, strings, dates, guids, etc.

--- a/PanoramicData.OData.Client/ODataQueryBuilder.ExpressionParsing.cs
+++ b/PanoramicData.OData.Client/ODataQueryBuilder.ExpressionParsing.cs
@@ -509,7 +509,7 @@ public partial class ODataQueryBuilder<T> where T : class
 	}
 
 	private static string GetMemberName(Expression<Func<T, object?>> selector) =>
-		MemberPathResolver.TryGetLeafMemberNameLoose(selector.Body, out var name)
+		MemberPathResolver.TryGetPathLoose(selector.Body, out var name)
 			? name
 			: throw new ArgumentException("Invalid selector expression");
 


### PR DESCRIPTION
## Summary

`.OrderBy(p => p.Nav.Prop)` and `.NavigateTo(p => p.Nav.Prop)` silently resolved only the leaf property name, dropping any intermediate navigation properties:

```csharp
.OrderBy(p => p.BestFriend.FirstName)   // produced $orderby=FirstName, not $orderby=BestFriend/FirstName
.NavigateTo(x => x.BestFriend.Friends)  // produced .../Friends, not .../BestFriend/Friends
```

This was one of four pre-existing truncation bugs surfaced (and deliberately preserved, not fixed) while consolidating member-path resolution in #36. It's fixed here on its own because it's the one of the four that's unambiguously safe: OData v4's `$orderby`/`$filter`/resource-path grammar formally supports `/`-paths through navigation properties, so the corrected output is fully spec-compliant.

The other three (`.Select`, `.ExpandWithSelect`, `NestedExpandBuilder.Select`) are **not** touched here - fixing those the same way would produce `$select` paths through navigation properties, which OData v4's `$select` grammar only defines for complex-typed properties, not navigation properties. That's a separate design question (ship anyway vs. validate-and-throw vs. defer), deliberately left open.

## Change

- `MemberPathResolver`: new `TryGetPathLoose`, mirroring the existing `TryGetLeafMemberNameLoose`'s loose Unary-gate but resolving the full path via the already-correct `GetFlatPath` instead of just the leaf name.
- `GetMemberName` (feeds both `OrderBy` and `NavigateTo`): swapped to call the new method.
- That's the entire production diff - one new method, one changed call.

## Tests

- Two existing tests that pinned the buggy truncated output are renamed and flipped to assert the fixed full-path output (`OrderBy_WithNestedExpression_ResolvesFullPath`, `NavigateTo_NonGenericExprNested_ResolvesFullPath`).
- One new 3-level-nesting regression test (`OrderBy_WithThreeLevelNestedExpression_ResolvesFullPath`).
- The three deferred `$select`-family characterization tests are untouched, still green, still pinning their bugs.
- Full suite: 787/787 passing. Clean Release build, zero warnings.

## Changelog

Added a `[10.0.88] - Fixed` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)