### PR TITLE
Add configurable entity set name resolution

### DIFF
--- a/PanoramicData.OData.Client.Test/UnitTests/ODataClientQueryTests.cs
+++ b/PanoramicData.OData.Client.Test/UnitTests/ODataClientQueryTests.cs
@@ -12,6 +12,8 @@ internal sealed class EntitySetAttribute(string entitySet) : Attribute
 [EntitySet("Mailbox")]
 internal sealed class GeneratedMailbox { }
 
+internal sealed class CustomResolvedEntity { }
+
 /// <summary>
 /// Unit tests for ODataClient query operations.
 /// </summary>
@@ -116,6 +118,48 @@ public class ODataClientQueryTests : TestBase, IDisposable
 		var url = _client.For<GeneratedMailbox>().BuildUrl();
 
 		// Assert
+		url.Should().Be("Mailbox");
+	}
+
+	/// <summary>
+	/// Tests that the configured entity set name resolver overrides the built-in conventions.
+	/// </summary>
+	[Fact]
+	public void For_EntitySetNameResolver_UsesResolvedName()
+	{
+		using var httpClient = new HttpClient(_mockHandler.Object) { BaseAddress = new Uri("https://test.odata.org/") };
+		using var client = new ODataClient(new ODataClientOptions
+		{
+			BaseUrl = "https://test.odata.org/",
+			HttpClient = httpClient,
+			Logger = NullLogger.Instance,
+			RetryCount = 0,
+			EntitySetNameResolver = type => type == typeof(CustomResolvedEntity) ? "custom_entities" : null
+		});
+
+		var url = client.For<CustomResolvedEntity>().BuildUrl();
+
+		url.Should().Be("custom_entities");
+	}
+
+	/// <summary>
+	/// Tests that a whitespace resolver result uses the existing entity set attribute convention.
+	/// </summary>
+	[Fact]
+	public void For_EntitySetNameResolverReturnsWhitespace_UsesEntitySetAttribute()
+	{
+		using var httpClient = new HttpClient(_mockHandler.Object) { BaseAddress = new Uri("https://test.odata.org/") };
+		using var client = new ODataClient(new ODataClientOptions
+		{
+			BaseUrl = "https://test.odata.org/",
+			HttpClient = httpClient,
+			Logger = NullLogger.Instance,
+			RetryCount = 0,
+			EntitySetNameResolver = _ => " "
+		});
+
+		var url = client.For<GeneratedMailbox>().BuildUrl();
+
 		url.Should().Be("Mailbox");
 	}
 

--- a/PanoramicData.OData.Client/ODataClient.Query.cs
+++ b/PanoramicData.OData.Client/ODataClient.Query.cs
@@ -469,6 +469,12 @@ public partial class ODataClient
 	{
 		var type = typeof(T);
 
+		var resolvedEntitySetName = _options.EntitySetNameResolver?.Invoke(type);
+		if (!string.IsNullOrWhiteSpace(resolvedEntitySetName))
+		{
+			return resolvedEntitySetName;
+		}
+
 		// Respect [EntitySet("...")] attribute from Microsoft.OData.Client generated DTOs
 		var entitySetAttr = type.GetCustomAttributes(false)
 			.FirstOrDefault(a => a.GetType().Name == "EntitySetAttribute");

--- a/PanoramicData.OData.Client/ODataClientOptions.cs
+++ b/PanoramicData.OData.Client/ODataClientOptions.cs
@@ -88,6 +88,16 @@ public class ODataClientOptions
 	public bool AutoPluralization { get; set; } = true;
 
 	/// <summary>
+	/// Gets or sets a function that resolves entity set names for <c>For&lt;T&gt;()</c> calls.
+	/// </summary>
+	/// <remarks>
+	/// When the function returns a non-empty value, the client uses it instead of the built-in
+	/// entity-set attribute and pluralization conventions. Return <c>null</c> or whitespace to
+	/// use those existing conventions.
+	/// </remarks>
+	public Func<Type, string?>? EntitySetNameResolver { get; set; }
+
+	/// <summary>
 	/// Gets or sets a value indicating whether a 404 Not Found response should return <c>null</c>
 	/// instead of throwing an <see cref="ODataNotFoundException"/>.
 	/// </summary>

--- a/README.md
+++ b/README.md
@@ -403,6 +403,10 @@ var client = new ODataClient(new ODataClientOptions
     
     // Optional: Custom JSON serialization settings
     JsonSerializerOptions = customOptions,
+
+    // Optional: Override entity set names used by For<T>()
+    // Return null to use the existing attribute and pluralization conventions
+    EntitySetNameResolver = type => type == typeof(LegacyProduct) ? "legacy_products" : null,
     
     // Optional: Configure headers for every request
     ConfigureRequest = request =>


### PR DESCRIPTION
## Summary

- Add an opt-in `EntitySetNameResolver` to resolve entity-set names for parameterless `For<T>()` calls.
- Preserve existing `[EntitySet]` and pluralization conventions when the resolver returns `null`, empty, or whitespace.
- Document the option and add focused coverage for resolver override and fallback behavior.

## Validation

- `dotnet build PanoramicData.OData.Client.Test/PanoramicData.OData.Client.Test.csproj --no-restore`
- `dotnet vstest PanoramicData.OData.Client.Test/bin/Debug/net10.0/PanoramicData.OData.Client.Test.dll --TestCaseFilter:"FullyQualifiedName~UnitTests"` (700 passed)